### PR TITLE
added a changelog redirect page

### DIFF
--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0;url=https://interlok.adaptris.net/interlok-docs/#/pages/overview/changelog" />
+    <title></title>
+  </head>
+ <body>
+   <script>
+    window.onload = function() {
+        // similar behavior as an HTTP redirect
+        window.location.replace("https://interlok.adaptris.net/interlok-docs/#/pages/overview/changelog");
+    }
+   </script>
+ </body>
+</html>


### PR DESCRIPTION
## Motivation

To allow older links to the changelog to get redirected to new changelog page

## Modification

added a changelog.html that redirects to new link

## Result

goto:
https://interlok.adaptris.net/interlok-docs/changelog.html 
should redirect to:
https://interlok.adaptris.net/interlok-docs/#/pages/overview/changelog


## Testing

navigate to:
https://interlok.adaptris.net/interlok-docs/changelog.html 
and it should redirect to:
https://interlok.adaptris.net/interlok-docs/#/pages/overview/changelog
