### PR TITLE
Update Mail & Add OneDrive documentation

### DIFF
--- a/docs/pages/cookbook/README.md
+++ b/docs/pages/cookbook/README.md
@@ -5,7 +5,7 @@
     - [Data Extract](/pages/cookbook/cookbook-jdbc-data-query.md)
  - [Email](/pages/cookbook/cookbook-email.md)
     - [POP3/IMAP/SMTP](/pages/cookbook/cookbook-pop3.md)
-    - [Office365](/pages/cookbook/cookbook-o365.md)
+    - [Outlook365](/pages/cookbook/cookbook-o365.md)
  - [HTTP](/pages/cookbook/cookbook-http.md)
     - [Making HTTP Requests](/pages/cookbook/cookbook-http-client.md)
     - [Servicing HTTP Requests](/pages/cookbook/cookbook-http-server.md)
@@ -28,3 +28,5 @@
     - [JSON Data Transforms](/pages/cookbook/cookbook-json-transform.md)
     - [CSV to XML](/pages/cookbook/cookbook-csv-transform.md)
     - [EDI Data Transforms](/pages/cookbook/cookbook-edi-transform.md)
+ - Cloud File Storage
+    - [OneDrive](/pages/cookbook/cookbook-1drive.md)

--- a/docs/pages/cookbook/cookbook-1drive.md
+++ b/docs/pages/cookbook/cookbook-1drive.md
@@ -13,7 +13,7 @@ small.
 
 * Active Office365 subscription
 * An Azure Active Directory application with application the following
-  permissions, and with [Admin Consent][2] granted:
+  permissions, and with [Admin Consent][1] granted:
   - Files.Read.All
   - Files.ReadWrite.All
   - User.Read
@@ -25,7 +25,7 @@ The OneDrive consumer, producer, and services require the above because:
 * As users cannot interact with daemon applications, incremental
   consent isn't possible
 * Users require a OneDrive, and this requires an
-  [Office365 subscription][3]
+  [Office365 subscription][2]
 
 ## Azure Application Setup
 
@@ -146,9 +146,8 @@ application ID, tenant ID, client secret, username, and a file name.
 
 ## Miscellaneous Notes/URLs
 
-[1]: https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-overview
-[2]: https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-daemon-overview
-[3]: https://docs.microsoft.com/en-us/microsoft-365/enterprise/azure-integration?view=o365-worldwide
+[1]: https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-daemon-overview
+[2]: https://docs.microsoft.com/en-us/microsoft-365/enterprise/azure-integration?view=o365-worldwide
 
 [8]: https://developer.microsoft.com/en-us/graph/graph-explorer
 [9]: https://github.com/Azure-Samples/active-directory-java-native-headless-v2


### PR DESCRIPTION
## Motivation

There was no documentation for OneDrive and the images showing how to setup Azure were not displaying.

## Modification

* Add documentation for OneDrive usage
* Update image references for Outlook documentation

## Result

There is now (at least) some information on how to get started with OneDrive.

## Testing

There should be images in the Outlook documentation, and there should be a new page for OneDrive setup.
