### PR TITLE
Interlok 3565 fix broken links

### DIFF
--- a/docs/pages/advanced/advanced-interlok-scaling.md
+++ b/docs/pages/advanced/advanced-interlok-scaling.md
@@ -62,7 +62,7 @@ In this guide we'll be using Interlok as a web server.  Therefore we'll expose a
 
 The following link will start a zip download of Apache JMeter;
 
-http://apache.mirrors.nublue.co.uk//jmeter/binaries/apache-jmeter-5.1.1.zip
+[http://apache.mirrors.nublue.co.uk/jmeter/binaries/apache-jmeter-5.2.1.zip](http://apache.mirrors.nublue.co.uk/jmeter/binaries/apache-jmeter-5.2.1.zip)
 
 Once downloaded, unzip to your preferred directory, example; C:\tools\apache-jmeter
  

--- a/docs/pages/advanced/advanced-version-control.md
+++ b/docs/pages/advanced/advanced-version-control.md
@@ -1,6 +1,6 @@
 Since 3.0.2 Interlok will support configuration that is controlled by a version control systems automagically. Configuration files can be stored in VCS, checked out/updated prior to any management components / adapter instances starting up. The properties mentioned here are in addition to any properties that are normally defined in `bootstrap.properties`; so you will still need an `adapterConfigUrl=` in order to source the configuration file.
 
-The default version control system is for Subversion via the [SVN Client Adapter from subclipse](http://subclipse.tigris.org) and JavaHL which wraps the core Subversion C API. Check the [version control with subversion](/pages/advanced/advanced-vcs-svn) document.
+The default version control system is for Subversion via the [SVN Client Adapter from subclipse](https://github.com/subclipse/svnclientadapter) and JavaHL which wraps the core Subversion C API. Check the [version control with subversion](/pages/advanced/advanced-vcs-svn) document.
 
 ## Start-Up ##
 

--- a/docs/pages/cookbook/cookbook-http-server.md
+++ b/docs/pages/cookbook/cookbook-http-server.md
@@ -7,7 +7,7 @@ As the name would suggest [jetty-embedded-connection][] makes use of the [jetty 
 
 There is currently only a single message consumer type: [jetty-message-consumer][]. The destination for the consumer should match the URI endpoint that you wish to listen on (e.g. /path/to/my/api); wildcards are supported and will be dependent on the servlet implementation of the underlying jetty instance. Parameters from the URI can be stored as metadata (or object metadata) with an optional prefix, as can any HTTP transport headers. If no [jetty-standard-response-producer][] or [jetty-response-service][] is configured as part of the workflow, then a standard HTTP OK response is sent back to the caller with no content.
 
-?> **TIP** You can use [http-request-parameter-converter-service][] to convert _html form post_ payloads into metadata, if required.
+?> **TIP** You can use [form-data-to-metadata][] to convert _html form post_ payloads into metadata, if required.
 
 There are a number of supporting components that make will help you configure a workflow that provides the behaviour you need.
 
@@ -267,7 +267,7 @@ Both [jetty-standard-response-producer][] and [jetty-response-service][] (3.6.5+
 [jetty-routing-service]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.11-SNAPSHOT/com/adaptris/core/http/jetty/JettyRoutingService.html
 [jetty-response-service]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.11-SNAPSHOT/com/adaptris/core/http/jetty/JettyResponseService.html
 [jetty-standard-response-producer]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.11-SNAPSHOT/com/adaptris/core/http/jetty/StandardResponseProducer.html
-[http-request-parameter-converter-service]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.11-SNAPSHOT/com/adaptris/core/http/RequestParameterConverterService.html
+[form-data-to-metadata]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.12-SNAPSHOT/com/adaptris/core/services/metadata/FormDataToMetadata.html
 [embedded-scripting-service]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.11-SNAPSHOT/com/adaptris/core/services/EmbeddedScriptingService.html
 [standard-workflow]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.11-SNAPSHOT/com/adaptris/core/StandardWorkflow.html
 [pooling-workflow]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.11-SNAPSHOT/com/adaptris/core/PoolingWorkflow.html

--- a/docs/pages/cookbook/cookbook-sap-idoc.md
+++ b/docs/pages/cookbook/cookbook-sap-idoc.md
@@ -35,7 +35,7 @@ Every time an IDoc is sent from/received by SAP, it is assigned a transaction ID
 
 ### Interlok Workflow Design ###
 
-We recommend that the Adapter registers as a single program and all IDocs (to all partners, and of all message types) are consumed via that single point. This means that you need to devise a strategy to control the behaviour of the workflow for different partners and message types. You can do this by extracting the required metadata and then using a [dynamic-service-locator][] to control the required services that are invoked. Use a [pooling-workflow][] to increase throughput.
+We recommend that the Adapter registers as a single program and all IDocs (to all partners, and of all message types) are consumed via that single point. This means that you need to devise a strategy to control the behaviour of the workflow for different partners and message types. You can do this by extracting the required metadata and then using a [dynamic-service-executor][] to control the required services that are invoked. Use a [pooling-workflow][] to increase throughput.
 
 ### Receiving an IDoc ###
 
@@ -168,7 +168,7 @@ You can track IDocs going into and out of the SAP system using _BD87_ to see all
 
 
 [sap-xml-tid-repository]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-sap/3.11-SNAPSHOT/com/adaptris/core/sap/XmlFileRepository.html
-[dynamic-service-locator]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.11-SNAPSHOT/com/adaptris/core/services/dynamic/DynamicServiceLocator.html
+[dynamic-service-executor]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.12-SNAPSHOT/com/adaptris/core/services/dynamic/DynamicServiceExecutor.html
 [sapjco3-idoc-consume-connection]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-sap/3.11-SNAPSHOT/com/adaptris/core/sap/jco3/idoc/IdocConsumeConnection.html
 [sapjco3-idoc-consumer]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-sap/3.11-SNAPSHOT/com/adaptris/core/sap/jco3/idoc/IdocConsumer.html
 [pooling-workflow]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.11-SNAPSHOT/com/adaptris/core/PoolingWorkflow.html

--- a/docs/pages/cookbook/cookbook-triggered-channel.md
+++ b/docs/pages/cookbook/cookbook-triggered-channel.md
@@ -47,8 +47,8 @@ In this instance we'll make the trigger a message on a JMS Topic; any message re
 </channel>
 ```
 
-[TriggeredChannel]: https://development.adaptris.net/nexus/content/groups/public/com/adaptris/interlok-triggered/
-[AdaptrisPollingConsumer]: https://development.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.8-SNAPSHOT/com/adaptris/core/AdaptrisPollingConsumer.html
-[JmsPollingConsumer]: https://development.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.8-SNAPSHOT/com/adaptris/core/jms/JmsPollingConsumer.html
-[FailedMessageRetrier]: https://development.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.8-SNAPSHOT/com/adaptris/core/FailedMessageRetrier.html
-[RetryMessageErrorHandler]: https://development.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.8-SNAPSHOT/com/adaptris/core/RetryMessageErrorHandler.html
+[TriggeredChannel]: https://nexus.adaptris.net/nexus/content/repositories/releases/com/adaptris/interlok-triggered/
+[AdaptrisPollingConsumer]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.12-SNAPSHOT/com/adaptris/core/AdaptrisPollingConsumer.html
+[JmsPollingConsumer]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.12-SNAPSHOT/com/adaptris/core/jms/JmsPollingConsumer.html
+[FailedMessageRetrier]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.12-SNAPSHOT/com/adaptris/core/FailedMessageRetrier.html
+[RetryMessageErrorHandler]: https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.12-SNAPSHOT/com/adaptris/core/RetryMessageErrorHandler.html

--- a/docs/pages/overview/adapter-what-is-it.md
+++ b/docs/pages/overview/adapter-what-is-it.md
@@ -67,7 +67,7 @@ The configuration file `adapter.xml` an XML representation of a graph of Java ob
 
 The standard camel case java naming convention is converted to use a `-` in XML element names, so `uniqueId` becomes `<unique-id>`; all string and primitive types are expressed as elements in XML and conversion is handled automatically. In cases where the property being set is an interface or abstract type, it is necessary to supply the runtime type of the implementation to use; which is where the `class=` attribute comes in (you can see this in the example above).
 
-All standard classes are [annotated with an alias](developer-annotations.html#class-level-annotations) which gives you a friendly name to use rather than the fully qualified class name. You can still use the fully qualified classname if you wish; but package/class names do change from time to time so using the friendly name is preferred. In the example above `fs-consumer` is the friendly name for the class `com.adaptris.core.fs.FsConsumer`.
+All standard classes are [annotated with an alias](/pages/developer/developer-annotations#class-level-annotations) which gives you a friendly name to use rather than the fully qualified class name. You can still use the fully qualified classname if you wish; but package/class names do change from time to time so using the friendly name is preferred. In the example above `fs-consumer` is the friendly name for the class `com.adaptris.core.fs.FsConsumer`.
 
 ## What is a Connection ##
 
@@ -87,7 +87,7 @@ An [AdaptrisMessageConsumer][] is responsible for receiving messages from the ta
 
 ## What is a Service ##
 
-[Services][Service] are a means of applying arbitrary functionality to messages and as such are the key low-level building block in Interlok. Examples of services included encrypting message payloads, applying XSLT transformations and extracting metadata using XPath or regular expressions. It is straightforward to create custom services if no existing off the shelf service meets a particular requirement (see [Custom Services](developer-services.html)).
+[Services][Service] are a means of applying arbitrary functionality to messages and as such are the key low-level building block in Interlok. Examples of services included encrypting message payloads, applying XSLT transformations and extracting metadata using XPath or regular expressions. It is straightforward to create custom services if no existing off the shelf service meets a particular requirement (see [Custom Services](/pages/developer/developer-services)).
 
 Services are often grouped into collections. Simple collections allow a linear list of services to be applied one after the other. More complex collections allow services to be applied conditionally based on configurable criteria, allowing complex processes to be modelled.
 

--- a/docs/pages/overview/changelog/release300.md
+++ b/docs/pages/overview/changelog/release300.md
@@ -4,14 +4,14 @@ Release Date : 2015-03-15
 
 Initial release of Interlok; key highlights are
 
-- [Shared Connections and JNDI](adapter-jndi-guide.html)
-- [Pre-processor for configuration files](advanced-configuration-pre-processors.html)
-- [Web based UI](ui-introduction.html) that
+- [Shared Connections and JNDI](/pages/user-guide/adapter-jndi-guide)
+- [Pre-processor for configuration files](/pages/advanced/advanced-configuration-pre-processors)
+- [Web based UI](/pages/ui/ui-introduction) that
     - Simplifies and Visualises Configuration
     - Testing via the UI.
     - Real-time monitoring of multiple adapters.
     - Real-time monitoring on failures (with the chance to retry directly from the UI).
     - Performance Diagnostics
-- [Adapter XML Schema using RelaxNG](advanced-configuration-pre-processors.html#schema-validation)
+- [Adapter XML Schema using RelaxNG](/pages/advanced/advanced-configuration-pre-processors#schema-validation)
 - Java 7 / Java 8 only.
 - A whole slew of changes under covers that are too numerous to mention

--- a/docs/pages/overview/changelog/release3100.md
+++ b/docs/pages/overview/changelog/release3100.md
@@ -20,7 +20,7 @@ Release Date : 2020-03-12
     - Initial support for Asynchronous messaging
     - The Default [JSON](https://github.com/adaptris/interlok-json) transformation driver is now "simple-json"
     - [apache-geode](https://github.com/adaptris/interlok-cache/tree/develop/interlok-apache-geode) is now supported as a caching provider
-    - Prototype support for [multi-payload messages](https://interlok.adaptris.net/interlok-docs/advanced-multi-payload-messages.html)
+    - Prototype support for [multi-payload messages](https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-multi-payload-messages)
     - The default Saxon [transformation engine](cookbook-xml-transform.html) has been upgraded from 9.8 to 9.9.x
 
 ### Bugs

--- a/docs/pages/overview/changelog/release3100.md
+++ b/docs/pages/overview/changelog/release3100.md
@@ -4,15 +4,15 @@ Release Date : 2020-03-12
 
 ### Key Highlights
 
-- The [UI Optional Component Page](ui-optional-component-discovery.html) has had many improvements, including:
+- The [UI Optional Component Page](/pages/ui/ui-optional-component-discovery) has had many improvements, including:
     - a reworked details modal that has had lots of new help text added to make things clearer
     - integration of project readme documents into the details window
     - more filtering options added, for better filtering of deprecated and licensed components
-- The [UI Service Tester Page](ui-service-tester.html) has had many improvements, including:
+- The [UI Service Tester Page](/pages/ui/ui-service-tester) has had many improvements, including:
     - A run option has been added to the test item that will run all its test cases.
     - When adding a new Test the Default Config File Source is now selected by default.
     - Improved the naming of tests when importing from existing config
-- The [UI User Preference](ui-user-preferences.html) 'Always attempt to load the active adapter' has now been set to false by default as we continue to promote the use of project based configuration.
+- The [UI User Preference](/pages/ui/ui-user-preferences) 'Always attempt to load the active adapter' has now been set to false by default as we continue to promote the use of project based configuration.
 - Interlok Runtime improvements include:
     - Added support for the Interlok to use the [Prometheus pushgateway](https://github.com/adaptris/interlok-profiler-prometheus)
     - By default, the standard [docker](https://hub.docker.com/r/adaptris/interlok/tags) images will run Interlok as an unprivileged user (You’ve always been able to run interlok as a unprivileged user, It just wasn’t done by default).
@@ -21,7 +21,7 @@ Release Date : 2020-03-12
     - The Default [JSON](https://github.com/adaptris/interlok-json) transformation driver is now "simple-json"
     - [apache-geode](https://github.com/adaptris/interlok-cache/tree/develop/interlok-apache-geode) is now supported as a caching provider
     - Prototype support for [multi-payload messages](https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-multi-payload-messages)
-    - The default Saxon [transformation engine](cookbook-xml-transform.html) has been upgraded from 9.8 to 9.9.x
+    - The default Saxon [transformation engine](/pages/cookbook/cookbook-xml-transform) has been upgraded from 9.8 to 9.9.x
 
 ### Bugs
 

--- a/docs/pages/overview/changelog/release3110.md
+++ b/docs/pages/overview/changelog/release3110.md
@@ -10,7 +10,7 @@ Release Date : 2020-09-22
     - [Json](https://github.com/adaptris/interlok-json) [Schema Validation](https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-json/3.11-SNAPSHOT/com/adaptris/core/json/schema/JsonSchemaService.html) now reports more detailed exceptions
     - [JsonTransformService](https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-json/3.11-SNAPSHOT/com/adaptris/core/transform/json/JsonTransformService.html) now supports json and yaml
     - [JSON](https://github.com/adaptris/interlok-json) can now be [encoded](https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-json-web-token/3.11-SNAPSHOT/com/adaptris/core/jwt/JWTEncoder.html) and [decoded](https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-json-web-token/3.11-SNAPSHOT/com/adaptris/core/jwt/JWTDecoder.html) to the [JWT](http://www.jsonwebtoken.io) ([JSON Web Token](https://github.com/adaptris/interlok-json-web-token)) standards
-    - Added support for a [HTTP endpoint](https://github.com/adaptris/interlok-workflow-rest-services) that [Prometheus can scrape for metrics](https://interlok.adaptris.net/interlok-docs/advanced-profiler-prometheus.html)
+    - Added support for a [HTTP endpoint](https://github.com/adaptris/interlok-workflow-rest-services) that [Prometheus can scrape for metrics](https://interlok.adaptris.net/interlok-docs/#/pages/advanced/advanced-profiler-prometheus)
     - Integrated asynchronous publishing via the JCSMP API into the Interlok bridging model.  We now support the basic message payload types of text, bytes, xml-bytes and xml-content.
 
 ### Bugs

--- a/docs/pages/overview/changelog/release341.md
+++ b/docs/pages/overview/changelog/release341.md
@@ -2,7 +2,7 @@
 
 Release Date : 2016-10-05
 
-!> **IMPORTANT** Because of issues with XStream and AliasedJavaBeanConverter not honouring some annotations; if you are using [JmsTransactedWorkflow](https://development.adaptris.net/javadocs/v3-snapshot/Interlok-API/com/adaptris/core/jms/JmsTransactedWorkflow.html) you will need to remove any interceptors manually and reconfigure them after upgrading.
+!> **IMPORTANT** Because of issues with XStream and AliasedJavaBeanConverter not honouring some annotations; if you are using [JmsTransactedWorkflow](https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.12-SNAPSHOT/com/adaptris/core/jms/JmsTransactedWorkflow.html) you will need to remove any interceptors manually and reconfigure them after upgrading.
 
 ### Key Highlights
 

--- a/docs/pages/overview/changelog/release380.md
+++ b/docs/pages/overview/changelog/release380.md
@@ -2,7 +2,7 @@
 
 Release Date : 2018-08-13
 
-This release requires Java 8; Java 7 is no longer supported. Additionally there were some artefact name changes which are documented in [optional components](adapter-optional-components.html).
+This release requires Java 8; Java 7 is no longer supported. Additionally there were some artefact name changes which are documented in [optional components](/pages/user-guide/adapter-optional-components).
 
 !> **IMPORTANT** Use interlok-boot.jar instead of adp-core.jar when running directly from the commandline; also adp-core.jar has been renamed to interlok-core.jar
 

--- a/docs/pages/overview/changelog/release390.md
+++ b/docs/pages/overview/changelog/release390.md
@@ -8,19 +8,19 @@ Release Date : 2019-06-25
 
 ### Key Highlights
 
-- [UI Projects](ui-config-project.html) - We have improved the [variable selector in the settings editor](ui-config-project.html#component-settings-modal) so it populates empty settings upon variable selection (making sure that element is outputted upon Apply Config)
-- [UI Projects](ui-config-project.html) - Our service testing features now support testing with variable sets
-- [UI Config Navigation Tree](ui-config-navigation-tree.html), there is now a new way to navigate the config page, which will make is easier to traverse large configuration
+- [UI Projects](/pages/ui/ui-config-project) - We have improved the [variable selector in the settings editor](/pages/ui/ui-config-project#component-settings-modal) so it populates empty settings upon variable selection (making sure that element is outputted upon Apply Config)
+- [UI Projects](/pages/ui/ui-config-project) - Our service testing features now support testing with variable sets
+- [UI Config Navigation Tree](/pages/ui/ui-config-navigation-tree), there is now a new way to navigate the config page, which will make is easier to traverse large configuration
 - The [config-conditional](https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.9.0-RELEASE/com/adaptris/core/services/conditional/package-summary.html) components have been promoted into the core Interlok release
 - New [Switch Service](https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.9.0-RELEASE/com/adaptris/core/services/conditional/Switch.html) which replaces some use cases for [branching-service-collection](https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.9.0-RELEASE/com/adaptris/core/BranchingServiceCollection.html)
-- Our [JMS/XA components](advanced-xa-integration.html) have been split into their own specific modules, i.e. XA-ActiveMQ, XA-Atomikos, XA-Solace, XA-Tibco, XA-WebsphereMQ & (a non- provider specific) XA-JMS
+- Our [JMS/XA components](/pages/advanced/advanced-xa-integration) have been split into their own specific modules, i.e. XA-ActiveMQ, XA-Atomikos, XA-Solace, XA-Tibco, XA-WebsphereMQ & (a non- provider specific) XA-JMS
 - The Email Integration components have been moved into their own optional component ([interlok-mail](https://github.com/adaptris/interlok-mail))
 - Also, the Flat file integration components have been moved into their own optional component ([interlok-flatfile](https://github.com/adaptris/interlok-flatfile))
 - There is now a [docker](https://hub.docker.com/r/adaptris/interlok/) image for Amazon Corretto + Azul
 - Some additional notes:
     - The new optional components, ([interlok-mail](https://github.com/adaptris/interlok-mail)) & ([interlok-flatfile](https://github.com/adaptris/interlok-flatfile)) are bundled into the 3.9.0 install. So this change has no immediate effect, once you install, they will still be in the 'lib' directory.
     - Config Items that were marked for removal in 3.9.0 have been removed, so there will be config changes if moving from 3.8 to 3.9
-    - The [UI Config Navigation Tree](ui-config-navigation-tree.html) is a beta feature, to access it you have to switch on the '[User Preferences](ui-user-preferences.html)'>'Enable technical preview features'
+    - The [UI Config Navigation Tree](/pages/ui/ui-config-navigation-tree) is a beta feature, to access it you have to switch on the '[User Preferences](/pages/ui/ui-user-preferences)'>'Enable technical preview features'
 
 ### Bugs
 

--- a/docs/pages/overview/changelog/release391.md
+++ b/docs/pages/overview/changelog/release391.md
@@ -4,18 +4,18 @@ Release Date : 2019-08-27
 
 ### Key Highlights
 
-- The [UI Config page](ui-config.html) has had many improvements including:
+- The [UI Config page](/pages/ui/ui-config) has had many improvements including:
      - Advanced settings view can be toggled on a per-component basis
      - When selecting a connection for a producer; we always try to display the most suitable connection first
-     - The [navigation tree](ui-config-navigation-tree.html) now displays Services (experimental)
+     - The [navigation tree](/pages/ui/ui-config-navigation-tree) now displays Services (experimental)
      - Improved validation when trying to import existing configuration into a project.
-- Microsoft SQL Server is now supported as the [UI database](ui-switch-db.html)
+- Microsoft SQL Server is now supported as the [UI database](/pages/ui/ui-switch-db)
 - A new management component that can cluster Interlok instances via jgroups ([interlok-cluster-manager](https://github.com/adaptris/interlok-cluster-manager))
 - New [interlok-elastic-rest](https://github.com/adaptris/interlok-elastic) optional component that uses the Elastic RestHighLevelClient. This supersedes all existing elasticsearch components, which have been deprecated and will be removed in a later release.
 - Amazon Kinesis is now supported as a produce target via [interlok-aws-kinesis](https://github.com/adaptris/interlok-aws/tree/develop/interlok-aws-kinesis)
 - org.eclipse.jetty.security.JDBCLoginService is now a valid login service to use with Jetty
-- [EDI transforms](cookbook-edi-transform.html) may now cache definitions via an external cache provider
-- [MessageAggregators](cookbook-aggregating-messages.html) can now filter messages prior to performing the actual aggregation.
+- [EDI transforms](/pages/cookbook/cookbook-edi-transform) may now cache definitions via an external cache provider
+- [MessageAggregators](/pages/cookbook/cookbook-aggregating-messages) can now filter messages prior to performing the actual aggregation.
 
 ### Bugs
 

--- a/docs/pages/overview/changelog/release392.md
+++ b/docs/pages/overview/changelog/release392.md
@@ -4,15 +4,15 @@ Release Date : 2019-10-22
 
 ### Key Highlights
 
-- The [UI Config page](ui-config.html) has had many improvements including:
+- The [UI Config page](/pages/ui/ui-config) has had many improvements including:
     - The validation process now produces warnings for deprecated usage.
-    - The [settings editor](ui-config.html#settings-editor-features) now has a 3 way toggle for viewing different levels of settings (normal, advanced and rare settings) making is easier to configure components.
-    - The [service testing](ui-test-service.html) features now support testing with 'MIME' encoded messages.
-- The [UI Component Search](ui-interlok-component-search.html) has been improved to return more accurate results.
-- A new exciting UI Page, the [Interlok Profiler](ui-profiler-monitor.html) is now available (you need to enable technical preview features), allowing you analysis runtime performance metrics.
+    - The [settings editor](/pages/ui/ui-config?id=settings-editor-features) now has a 3 way toggle for viewing different levels of settings (normal, advanced and rare settings) making is easier to configure components.
+    - The [service testing](/pages/ui/ui-test-service) features now support testing with 'MIME' encoded messages.
+- The [UI Component Search](/pages/ui/ui-interlok-component-search) has been improved to return more accurate results.
+- A new exciting UI Page, the [Interlok Profiler](/pages/ui/ui-profiler-monitor) is now available (you need to enable technical preview features), allowing you analysis runtime performance metrics.
 - New services to provide [PGP](https://en.wikipedia.org/wiki/Pretty_Good_Privacy) encryption, decryption, signing, and verification ([interlok-pgp](https://github.com/adaptris/interlok-pgp)).
 - FtpConsumers now support a range of FileFilters, including filters that aren't just 'name based'.
-- Interlok now supports JMS 2.0 asynchronous producers with [XA transactions](advanced-xa-integration.html).
+- Interlok now supports JMS 2.0 asynchronous producers with [XA transactions](/pages/advanced/advanced-xa-integration).
 - New simplified cache services that are simpler to configure and avoid XML bloat.
 - HikariCP is now supported as an implementation for Pooled JDBC Connections.
 - New alterative authentication schemes for [AWS](https://github.com/adaptris/interlok-aws).

--- a/docs/pages/overview/changelog/release393.md
+++ b/docs/pages/overview/changelog/release393.md
@@ -5,11 +5,11 @@ Release Date : 2020-01-06
 ### Key Highlights
 
 - You can now add comments to your Interlok [Channels](https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.9.3-RELEASE/com/adaptris/core/Channel.html#setComments-java.lang.String-), [Workflows](https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.9.3-RELEASE/com/adaptris/core/WorkflowImp.html#setComments-java.lang.String-) and [Service Collections](https://nexus.adaptris.net/nexus/content/sites/javadocs/com/adaptris/interlok-core/3.9.3-RELEASE/com/adaptris/core/ServiceCollection.html)
-- The [UI Config Page Navigation Tree](ui-config-navigation-tree.html) has been improved to display more collection components and now has a 'focus' mode.
-- A new MultiPayloadMessageFactory that enables AdaptrisMessage to support [multiple payloads](advanced-multi-payload-messages.html)
+- The [UI Config Page Navigation Tree](/pages/ui/ui-config-navigation-tree) has been improved to display more collection components and now has a 'focus' mode.
+- A new MultiPayloadMessageFactory that enables AdaptrisMessage to support [multiple payloads](/pages/advanced/advanced-multi-payload-messages)
 - Additional Services that allow you to Add payloads to MultiPayloadMessage and switch the active payload for other services to work on
-- The [UI Config page](https://interlok.adaptris.net/interlok-docs/#/pages/ui/ui-config) has improved the opening of [shared service collections](ui-config.html#shared-components-area) from the shared components within config
-- The [UI Profiler](ui-profiler-monitor.html) has been updated to allow multiple adapter/channel panels at the same time.
+- The [UI Config page](/pages/ui/ui-config) has improved the opening of [shared service collections](/pages/ui/ui-config?id=shared-components-area) from the shared components within config
+- The [UI Profiler](/pages/ui/ui-profiler-monitor) has been updated to allow multiple adapter/channel panels at the same time.
 - Interlok now supports NATS messaging (optional component [interlok-nats](https://github.com/adaptris/interlok-nats))
 - Added support for 'JSON Lines' in [json](https://github.com/adaptris/interlok-json)/[csv-json](https://github.com/adaptris/interlok-csv-json)/[elastic](https://github.com/adaptris/interlok-elastic) optional components
 

--- a/docs/pages/overview/changelog/release393.md
+++ b/docs/pages/overview/changelog/release393.md
@@ -8,7 +8,7 @@ Release Date : 2020-01-06
 - The [UI Config Page Navigation Tree](ui-config-navigation-tree.html) has been improved to display more collection components and now has a 'focus' mode.
 - A new MultiPayloadMessageFactory that enables AdaptrisMessage to support [multiple payloads](advanced-multi-payload-messages.html)
 - Additional Services that allow you to Add payloads to MultiPayloadMessage and switch the active payload for other services to work on
-- The [UI Config page](https://interlok.adaptris.net/interlok-docs/ui-config.html) has improved the opening of [shared service collections](ui-config.html#shared-components-area) from the shared components within config
+- The [UI Config page](https://interlok.adaptris.net/interlok-docs/#/pages/ui/ui-config) has improved the opening of [shared service collections](ui-config.html#shared-components-area) from the shared components within config
 - The [UI Profiler](ui-profiler-monitor.html) has been updated to allow multiple adapter/channel panels at the same time.
 - Interlok now supports NATS messaging (optional component [interlok-nats](https://github.com/adaptris/interlok-nats))
 - Added support for 'JSON Lines' in [json](https://github.com/adaptris/interlok-json)/[csv-json](https://github.com/adaptris/interlok-csv-json)/[elastic](https://github.com/adaptris/interlok-elastic) optional components

--- a/docs/pages/ui/ui-optional-component-discovery.md
+++ b/docs/pages/ui/ui-optional-component-discovery.md
@@ -34,7 +34,7 @@ Clicking on the view more details button shows the optional component details wi
 
 ![Optional Component Discovery Details](../../images/ui-user-guide/optional-component-details.png)
 
-This modal shows some options and the dependencies that the component has and a link for the install instructions which takes you to [this documentation page][]
+This modal shows some options and the dependencies that the component has and a link for the install instructions which takes you to [this documentation page](/pages/user-guide/adapter-optional-components?id=how-to-install)
 
 ## Optional Component Detector ##
 
@@ -48,4 +48,3 @@ To change the selected Adapter just click on the dropdown and choose a different
 
 
 [artifact server]: https://nexus.adaptris.net/nexus/content/groups/
-[this documentation page]: https://development.adaptris.net/docs/Interlok/adapter-optional-components.html#how-to-install

--- a/docs/pages/user-guide/adapter-bootstrap.md
+++ b/docs/pages/user-guide/adapter-bootstrap.md
@@ -69,7 +69,7 @@ Management components are Interlok components that exist outside of the normal a
 
 #### JMX Component ####
 
-!> **WARNING** By default the JMXMP connector is run without authentication enabled.  For production environments it is highly recommended you enable JMXMP authentication as documented [here](/pages/https://interlok.adaptris.net/interlok/https://interlok.adaptris.net/interlok-docs/advanced-jmx).  Further information on the vulnerabilities of un-protected JMX can be found in [this blog post](https://www.acunetix.com/blog/web-security-zone/old-java-libraries/) by Aleksei Tiurin
+!> **WARNING** By default the JMXMP connector is run without authentication enabled.  For production environments it is highly recommended you enable JMXMP authentication as documented [here](/pages/advanced/advanced-jmx).  Further information on the vulnerabilities of un-protected JMX can be found in [this blog post](https://www.acunetix.com/blog/web-security-zone/old-java-libraries/) by Aleksei Tiurin
 
 If the JMX management component is specified via `managementComponents=jmx` then additional keys in bootstrap.properties determine the behaviour of the component.
 

--- a/docs/pages/user-guide/adapter-optional-components.md
+++ b/docs/pages/user-guide/adapter-optional-components.md
@@ -61,7 +61,7 @@ As additional features are developed and released our public facing repository i
 |com.adaptris | [interlok-jmx-jms-common][]| Provider neutral runtime support for [JMX via JMS or AMQP 1.0](/pages/advanced/advanced-jmx-jms) | 3.10+ | available on [github](https://github.com/adaptris/interlok-jmx-jms)
 |com.adaptris | [interlok-jmx-solace][]| Solace Provider for [JMX via JMS or AMQP 1.0](/pages/advanced/advanced-jmx-jms) | 3.10+ | available on [github](https://github.com/adaptris/interlok-jmx-jms)
 |com.adaptris | [interlok-jmx-sonicmq][]| SonicMQ Provider for [JMX via JMS or AMQP 1.0](/pages/advanced/advanced-jmx-jms) | 3.10+ |
-|com.adaptris | [interlok-jruby][] | Tighter coupling with [jruby](http://jruby.org) as an alternative to [ScriptingService][]/[EmbeddedScriptingService][]|3.6.3+ | available on [github](https://github.com/adaptris/interlok-jruby)
+|com.adaptris | [interlok-jruby][] | Tighter coupling with [jruby](https://www.jruby.org) as an alternative to [ScriptingService][]/[EmbeddedScriptingService][]|3.6.3+ | available on [github](https://github.com/adaptris/interlok-jruby)
 |com.adaptris | [interlok-jsr107-cache][] | Cache implementation that wraps JSR107 cache implementations |3.8.0+ | available on [github](https://github.com/adaptris/interlok-cache)
 |com.adaptris | [interlok-jq][] | JSON transformations using JQ-like syntax |3.7.0+ | available on [github](https://github.com/adaptris/interlok-jq)
 |com.adaptris | [interlok-json][] | Transform JSON data to and from XML | 3.8.0+ |available on [github](https://github.com/adaptris/interlok-json)

--- a/docs/pages/user-guide/adapter-optional-components.md
+++ b/docs/pages/user-guide/adapter-optional-components.md
@@ -93,8 +93,8 @@ As additional features are developed and released our public facing repository i
 |com.adaptris | ~~[interlok-restful-services][]~~ | ~~[Exposing Workflows as a RESTful service](/pages/user-guide/adapter-hosting-rest)~~|3.8.0 to 3.8.2 only; removed in 3.8.3
 |com.adaptris | [interlok-reliable-messaging][] | Support for ordered and reliable messaging; requires [interlok-licensing][] | 3.8.0+
 |com.adaptris | ~~[interlok-salesforce][]~~ | ~~Integration with Salesforce via WebServices (generally use their REST interface via HTTP/HTTPS instead); requires [interlok-licensing][]~~ | 3.8.0+| Use their REST API instead.
-|com.adaptris | [interlok-sap][] | Integration with SAP via [IDocs](/pages/cookbook/cookbook-sap-idoc.html) or [RFC/BAPI](cookbook-sap-rfc); requires additional jars not automatically delivered; requires [interlok-licensing][] | 3.8.0+
-|com.adaptris | ~~[interlok-schema][]~~ | ~~RelaxNG [schema validation](advanced-configuration-pre-processors.html#schema-validation) for Interlok configuration files~~ | 3.8.0-3.10.2, deprecated since 3.9.0; removed in 3.11.0
+|com.adaptris | [interlok-sap][] | Integration with SAP via [IDocs](/pages/cookbook/cookbook-sap-idoc) or [RFC/BAPI](/pages/cookbook/cookbook-sap-rfc); requires additional jars not automatically delivered; requires [interlok-licensing][] | 3.8.0+
+|com.adaptris | ~~[interlok-schema][]~~ | ~~RelaxNG [schema validation](/pages/advanced/advanced-configuration-pre-processors#schema-validation) for Interlok configuration files~~ | 3.8.0-3.10.2, deprecated since 3.9.0; removed in 3.11.0
 |com.adaptris | [interlok-service-tester][] | Testing services as part of a CI pipeline | 3.5.0+ | available on [github](https://github.com/adaptris/interlok-service-tester)
 |com.adaptris | [interlok-shell][] | Commandline runtime UI based on [CRaSH](http://www.crashub.org) | 3.4.1+, deprecated since 3.11.0 |available on [github](https://github.com/adaptris/interlok-shell)
 |com.adaptris | [interlok-socket][] | Vanilla Socket support; migrated from [interlok-core][] into its own component  | 3.7.0+ | available on [github](https://github.com/adaptris/interlok-socket)
@@ -118,7 +118,7 @@ As additional features are developed and released our public facing repository i
 |com.adaptris | ~~[interlok-web-services][]~~ | ~~[Exposing workflows as webservices](/pages/user-guide/adapter-hosting-ws);~~ | 3.8.0-3.10.2; removed in 3.11.0
 |com.adaptris | [interlok-webspheremq][] | Connection to a [WebsphereMQ instance](/pages/cookbook/cookbook-native-wmq); requires [interlok-licensing][] | 3.8.0+
 |com.adaptris | [interlok-workflow-rest-services][] | [Exposing Workflows as a RESTful service](/pages/user-guide/adapter-hosting-rest) | 3.8.3+|available on [github](https://github.com/adaptris/interlok-workflow-rest-services)
-|com.adaptris | [interlok-xinclude][] | [XInclude pre-processor](advanced-configuration-pre-processors.html#xinclude)| 3.8.0+|available on [github](https://github.com/adaptris/interlok-xinclude)
+|com.adaptris | [interlok-xinclude][] | [XInclude pre-processor](/pages/advanced/advanced-configuration-pre-processors#xinclude)| 3.8.0+|available on [github](https://github.com/adaptris/interlok-xinclude)
 |com.adaptris | ~~[interlok-xa][]~~ | ~~XA support within the Adapter; requires [interlok-licensing][]~~ | 3.4.0 - 3.8.4; removed in 3.9.0 | XA support was split into various sub modules; see below
 |com.adaptris | [interlok-xa-activemq][] | ActiveMQ XA JMS Vendor implementaiton; requires [interlok-licensing][] | 3.9.0+
 |com.adaptris | [interlok-xa-atomikos][] | XA support using Atomikos as the transaction manage; requires [interlok-licensing][] | 3.9.0+ | Use this artefact in conjunction one of the other supported providers
@@ -220,7 +220,7 @@ In release 3.8.0; we renamed all the artefacts so that they consistently started
 |com.adaptris | [adp-restful-services][] | [Exposing Workflows as a RESTful service](/pages/user-guide/adapter-hosting-rest)|3.0.6 - 3.7.3 |  _since 3.8.0_ use [interlok-restful-services][] instead
 |com.adaptris | [adp-reliable-messaging][] | Support for ordered and reliable messaging; requires [adp-licensing][] | until 3.7.3 |  _since 3.8.0_ use [interlok-reliable-messaging][] instead
 |com.adaptris | [adp-salesforce][] | Integration with Salesforce via WebServices (generally use their REST interface via HTTP/HTTPS instead); requires [adp-licensing][] | until 3.7.3 |  _since 3.8.0_ use [interlok-salesforce][] instead
-|com.adaptris | [adp-sap][] | Integration with SAP via [IDocs](/pages/cookbook/cookbook-sap-idoc) or [RFC/BAPI](cookbook-sap-rfc); requires additional jars not automatically delivered; requires [adp-licensing][] | until 3.7.3 |  _since 3.8.0_ use [interlok-sap][] instead.
+|com.adaptris | [adp-sap][] | Integration with SAP via [IDocs](/pages/cookbook/cookbook-sap-idoc) or [RFC/BAPI](/pages/cookbook/cookbook-sap-rfc); requires additional jars not automatically delivered; requires [adp-licensing][] | until 3.7.3 |  _since 3.8.0_ use [interlok-sap][] instead.
 |com.adaptris | [adp-schema][] | RelaxNG [schema validation](/pages/advanced/advanced-configuration-pre-processors#schema-validation) for Interlok configuration files | until 3.7.3 |  _since 3.8.0_ use [interlok-schema][] instead.
 |com.adaptris | [adp-simple-csv][] | Transform a CSV file to XML | until 3.7.3 |  _since 3.8.0_ use [interlok-csv][] instead.
 |com.adaptris | [adp-solace][] | Integration with Solace Systems as a JMS provider; requires additional jars not automatically delivered; requires [adp-licensing][]| until 3.7.3 |  _since 3.8.0_ use [interlok-solace][] instead.


### PR DESCRIPTION
## Motivation

Since the upgrade to the docs website, we've had broken links on our pages.

## Modification

- updated adapter-bootstrap.md (the advanced-jmx link)
- updated cookbook-sap-idoc.md (dynamic-service-locator to dynamic-service-executor)
- updated cookbook-http-server.md, from RequestParameterConverterService to FormDataToMetadata
- updated cookbook-triggered-channel.md, all links pointing to development.adaptris.net/nexus/content/sites/javadocs/ updated to nexus.adaptris.net/nexus/content/sites/javadocs
- updated advanced-version-control.md, from http://subclipse.tigris.org/ to https://github.com/subclipse/svnclientadapter
- updated advanced-interlok-scaling.md, updated the apache-jmeter-5.2.1.zip link
- updated adapter-optional-components.md, updated jruby.org link
- updated release393.md, release3110.md, release3100.md, updated various Key Highlights links
- updated release391.md, release392.md, release393.md, updated various Key Highlights links
- updated ui-optional-component-discovery.md, updated the how-to-install link
- updated release341.md, updated JmsTransactedWorkflow.html javadoc link

## Result

docs site without broken links

## Testing

look/click links that have been replaced.
