### PR TITLE
updated some references to java versions; added various notes in places

### DIFF
--- a/docs/pages/advanced/advanced-ant-ivy-deploy.md
+++ b/docs/pages/advanced/advanced-ant-ivy-deploy.md
@@ -14,6 +14,8 @@ In this worked example we will be using [Apache Ant][] and [Apache Ivy][] to man
 - Ant 1.9+
 - JDK 8 (as you'll need this to run Interlok from 3.8 onwards)
 
+!> **IMPORTANT:** **Interlok 3.8+ requires at least Java 8 and Interlok 4.0+ requires Java 11**.
+
 The files are:
 
 - `ivy/ivy-settings.xml` : contains resolvers and settings for your build.

--- a/docs/pages/advanced/advanced-failover.md
+++ b/docs/pages/advanced/advanced-failover.md
@@ -195,7 +195,7 @@ A short example of a windows start script; the last line setting the argument an
 
 ```
 set ADAPTRIS_HOME=C:\Adaptris\Interlok
-set JAVA_HOME=C:\Java\jdk1.8\bin
+set JAVA_HOME=C:\Java\jdk\bin
 
 cd %ADAPTRIS_HOME%
 %JAVA_HOME%\bin\java -jar lib\interlok-boot.jar --failover bootstrap.properties

--- a/docs/pages/advanced/advanced-sonic-container.md
+++ b/docs/pages/advanced/advanced-sonic-container.md
@@ -5,7 +5,7 @@
 !> **IMPORTANT** **Interlok SonicMF is deprecated since 3.11.1** and **will be removed in version 4.0**.
 
 
-Interlok requires a minimum JVM version of 1.7. SonicMQ version 8.5 and earlier may be running with Java 1.6.  In this case you will need a separate install of Java 1.7 on the SonicMQ host machine. You can download the required files from either then [snapshot repository](https://nexus.adaptris.net/nexus/content/groups/adaptris-snapshots/com/adaptris/interlok-sonicmf/) or the [release repository](https://nexus.adaptris.net/nexus/content/groups/public/com/adaptris/interlok-sonicmf/).
+Interlok requires a minimum JVM version of 1.8 (Interlok 4 requires Java 11). SonicMQ version 8.5 and earlier may be running with Java 1.6.  In this case you will need a separate install of Java 1.8 on the SonicMQ host machine. You can download the required files from either then [snapshot repository](https://nexus.adaptris.net/nexus/content/groups/adaptris-snapshots/com/adaptris/interlok-sonicmf/) or the [release repository](https://nexus.adaptris.net/nexus/content/groups/public/com/adaptris/interlok-sonicmf/).
 
 ----
 
@@ -132,6 +132,8 @@ Should you choose to upload your bootstrap.properties into the sonicfs, you may 
 The main reason for using the bootstrap.properties.url deployment parameter above the previous method would be to be able to have the full leverage of pre-processors and custom parameters within the bootstrap.properties.
 
 Next, you need to make sure the SonicMQ container starts Interlok with the correct version of java. By default all container components will be executed with the version installed with SonicMQ.  You may need to specify a later version of Java. To do this, you can edit your custom container and make sure the path to your java 1.8+ installation is specified as shown here;
+
+!> **IMPORTANT:** **Remember that Interlok 3.8+ requires Java 8 and Interlok 4.0+ requires Java 11**.
 
 ![Java version](../../images/sonic-container/sonicmq-container-Figure8.png)
 

--- a/docs/pages/advanced/advanced-webspheremq-ssl.md
+++ b/docs/pages/advanced/advanced-webspheremq-ssl.md
@@ -145,7 +145,7 @@ If you have your own Interlok start script simply add these parameters to the Ja
 ```
 set CLASSPATH=.
 set ADAPTRIS_HOME=C:\Adaptris\3.6.6
-set JAVA_HOME=C:\Java\jdk1.8.0_144\bin
+set JAVA_HOME=C:\Java\jdk\bin
 
 set CLASSPATH=%CLASSPATH%;%ADAPTRIS_HOME%\lib\*;%ADAPTRIS_HOME%\config
 

--- a/docs/pages/developer/developer-profiler.md
+++ b/docs/pages/developer/developer-profiler.md
@@ -21,7 +21,7 @@ setlocal ENABLEDELAYEDEXPANSION
 
 set CLASSPATH=.
 set INTERLOK_HOME=C:\Adaptris\3.10
-set JAVA_HOME=C:\Java\Zulu\zulu-8\bin
+set JAVA_HOME=C:\Java\jdk\bin
 
 set CLASSPATH=%CLASSPATH%;%INTERLOK_HOME%\lib\*;%INTERLOK_HOME%\config
 

--- a/docs/pages/overview/adapter-changes-since-2.x.md
+++ b/docs/pages/overview/adapter-changes-since-2.x.md
@@ -7,7 +7,9 @@ permalink: adapter-changes-since-2.x.html
 summary: This is a brief guide about what's changed in the adapter..
 ---
 
-- It requires Java 7
+!> **NOTE:** **Interlok 3.8+ requires at least Java 8 and Interlok 4.0+ requires Java 11**.
+
+- Interlok 3.0+ requires Java 7
 - There is now a web based UI
 - The underlying XML has been migrated from Castor to XStream
 - The XPath / XSLT engine has switched from Xalan to Saxon-HE

--- a/docs/pages/overview/adapter-installation.md
+++ b/docs/pages/overview/adapter-installation.md
@@ -1,6 +1,6 @@
 # Interlok Installation #
 
-?> **NOTE** 3.8.0 and later will require at least Java 8
+!> **NOTE:** **Interlok 3.8+ requires at least Java 8 and Interlok 4.0+ requires Java 11**.
 
 Installation is pretty easy. Download the installer, and execute it; due to a change in Java licensing as of 2019 you need to provide your own 64bit JVM.
 
@@ -66,9 +66,9 @@ INSTALLER_UI=silent
 INSTALL_AS_SERVICE=0
 
 # Only required if you aren't installing with the JVM bundle.
-JDK_HOME=/opt/java/jdk1.7
-JAVA_DOT_HOME=/opt/java/jdk1.7
-JAVA_EXECUTABLE=/opt/java/jdk1.7/bin/java
+JDK_HOME=/opt/java/jdk
+JAVA_DOT_HOME=/opt/java/jdk
+JAVA_EXECUTABLE=/opt/java/jdk/bin/java
 
 ```
 

--- a/docs/pages/overview/adapter-installation.md
+++ b/docs/pages/overview/adapter-installation.md
@@ -49,7 +49,7 @@ If you are in this situation, you should install with the bundled JRE (using `in
 On Some platforms; you may not be able to execute the installer without explicitly providing path to the java executable. This can be done by passing in the LAX_VM switch on the commandline and works on both Windows and Unix platforms. On Unix systems; if you installed java via the distribution repos, then you may not have a JAVA_HOME environment variable; the installer may not be able to find java.
 
 ```
-.\install-without-jre.exe LAX_VM "C:\Program Files\jdk1.8.0_102\bin\javaw.exe"
+.\install-without-jre.exe LAX_VM "C:\Program Files\jdk\bin\javaw.exe"
 sh ./install-without-jre.bin LAX_VM "/docker-java-home/bin/java"
 ```
 


### PR DESCRIPTION
## Motivation

Interlok 4.0 requires java 11 and there are places in the docs where we reference java versions.

## Modification

some places I changed things like 
```
set JAVA_HOME=C:\Java\jdk1.8\bin
```

to just 
```
set JAVA_HOME=C:\Java\jdk\bin
```
thus removing the version number.

and in other places I addeds note/important notices, such as:
```
!> **NOTE:** **Interlok 3.8+ requires at least Java 8 and Interlok 4.0+ requires Java 11**.
```

## Result

Documentation should really be java version clean, except where we can't be, then there's a note about versions.

## Testing

checkout branch
docsify serve docs

read pages:

- docs/pages/advanced/advanced-ant-ivy-deploy.md
- docs/pages/advanced/advanced-failover.md
- docs/pages/advanced/advanced-sonic-container.md
- docs/pages/advanced/advanced-webspheremq-ssl.md
- docs/pages/developer/developer-profiler.md
- docs/pages/overview/adapter-changes-since-2.x.md
- docs/pages/overview/adapter-installation.md

should all make sense
