### PR TITLE
Update references to destinations

### DIFF
--- a/docs/files/cookbook/email/adapter.xml
+++ b/docs/files/cookbook/email/adapter.xml
@@ -2,7 +2,6 @@
   <unique-id>MyInterlokInstance</unique-id>
   <start-up-event-imp>com.adaptris.core.event.StandardAdapterStartUpEvent</start-up-event-imp>
   <heartbeat-event-imp>com.adaptris.core.HeartbeatEvent</heartbeat-event-imp>
-  <log-handler class="null-log-handler"/>
   <shared-components>
     <connections/>
   </shared-components>
@@ -36,11 +35,9 @@
         <standard-workflow>
           <consumer class="raw-mail-consumer">
             <unique-id>raw-mail-consumer</unique-id>
-            <destination class="configured-consume-destination">
-              <destination>pop3://mail.local:110/INBOX</destination>
-              <filter-expression>SUBJECT=^consume me.*$</filter-expression>
-            </destination>
-            <poller class="fixed-interval-poller">
+              <mailbox-url>pop3://mail.local:110/INBOX</mailbox-url>
+			  <filter-expression>SUBJECT=^consume me.*$</filter-expression>
+              <poller class="fixed-interval-poller">
               <poll-interval>
                 <unit>SECONDS</unit>
                 <interval>30</interval>
@@ -60,9 +57,7 @@
           <producer class="fs-producer">
             <encoder class="mime-encoder"/>
             <unique-id>fs-producer</unique-id>
-            <destination class="configured-produce-destination">
-              <destination>file:////C:/apps/Adaptris/Interlok/test/mail-drop-raw</destination>
-            </destination>
+			<base-directory-url>file:////C:/apps/Adaptris/Interlok/test/mail-drop-raw</base-directory-url>
             <create-dirs>true</create-dirs>
             <fs-worker class="fs-nio-worker"/>
             <filename-creator class="formatted-filename-creator">
@@ -83,10 +78,8 @@
         <standard-workflow>
           <consumer class="default-mail-consumer">
             <unique-id>default-mail-consumer-without-selector</unique-id>
-            <destination class="configured-consume-destination">
-              <destination>pop3://mail.local:110/INBOX</destination>
-              <filter-expression>SUBJECT=^consume me.*$</filter-expression>
-            </destination>
+			<mailbox-url>pop3://mail.local:110/INBOX</mailbox-url>
+			<filter-expression>SUBJECT=^consume me.*$</filter-expression>
             <poller class="fixed-interval-poller">
               <poll-interval>
                 <unit>SECONDS</unit>
@@ -99,8 +92,9 @@
             <mail-receiver-factory class="javamail-receiver-factory">
               <session-properties/>
             </mail-receiver-factory>
-            <preserve-headers>true</preserve-headers>
-            <header-prefix>MailHeader-</header-prefix>
+  		    <header-handler class="mail-headers-as-metadata">
+			  <prefix>MailHeader-</prefix>
+		    </header-handler>
           </consumer>
           <service-collection class="service-list">
             <unique-id>ServiceList-8225643</unique-id>
@@ -109,9 +103,7 @@
           <producer class="fs-producer">
             <encoder class="mime-encoder"/>
             <unique-id>fs-producer</unique-id>
-            <destination class="configured-produce-destination">
-              <destination>file:////C:/apps/Adaptris/Interlok/test/mail-drop-default-without-selector</destination>
-            </destination>
+			<base-directory-url>file:////C:/apps/Adaptris/Interlok/test/mail-drop-default-without-selector</base-directory-url>
             <create-dirs>true</create-dirs>
             <fs-worker class="fs-nio-worker"/>
             <filename-creator class="formatted-filename-creator">
@@ -132,10 +124,8 @@
         <standard-workflow>
           <consumer class="default-mail-consumer">
             <unique-id>default-mail-consumer-with-selector</unique-id>
-            <destination class="configured-consume-destination">
-              <destination>pop3://mail.local:110/INBOX</destination>
-              <filter-expression>SUBJECT=^consume me.*$</filter-expression>
-            </destination>
+			<mailbox-url>pop3://mail.local:110/INBOX</mailbox-url>
+			<filter-expression>SUBJECT=^consume me.*$</filter-expression>
             <poller class="fixed-interval-poller">
               <poll-interval>
                 <unit>SECONDS</unit>
@@ -151,8 +141,9 @@
             <part-selector class="mime-select-by-position">
               <position>0</position>
             </part-selector>
-            <preserve-headers>true</preserve-headers>
-            <header-prefix>MailHeader-</header-prefix>
+			<header-handler class="mail-headers-as-metadata">
+			  <prefix>MailHeader-</prefix>
+			</header-handler>
           </consumer>
           <service-collection class="service-list">
             <unique-id>ServiceList-8225643</unique-id>
@@ -161,9 +152,7 @@
           <producer class="fs-producer">
             <encoder class="mime-encoder"/>
             <unique-id>fs-producer</unique-id>
-            <destination class="configured-produce-destination">
-              <destination>file:////C:/apps/Adaptris/Interlok/test/mail-drop-default-with-selector</destination>
-            </destination>
+			<base-directory-url>file:////C:/apps/Adaptris/Interlok/test/mail-drop-default-with-selector</base-directory-url>
             <create-dirs>true</create-dirs>
             <fs-worker class="fs-nio-worker"/>
             <filename-creator class="formatted-filename-creator">
@@ -195,9 +184,7 @@
         <standard-workflow>
           <consumer class="fs-consumer">
             <unique-id>fs-consumer</unique-id>
-            <destination class="configured-consume-destination">
-              <destination>file:////C:/apps/Adaptris/Interlok/test/mail-pickup-default-no-attachment</destination>
-            </destination>
+			<base-directory-url>file:////C:/apps/Adaptris/Interlok/test/mail-pickup-default-no-attachment</base-directory-url>
             <poller class="fixed-interval-poller">
               <poll-interval>
                 <unit>SECONDS</unit>
@@ -220,23 +207,17 @@
               </add-metadata-service>
             </services>
           </service-collection>
-          <producer class="default-smtp-producer">
-            <unique-id>default-smtp-producer</unique-id>
-            <destination class="configured-produce-destination">
-              <destination>imap@mail.local</destination>
-            </destination>
-            <smtp-url>smtp://mail.local:25</smtp-url>
-            <subject>Test email sent by Interlok</subject>
-            <from>pop3@mail.local</from>
-            <session-properties/>
-            <metadata-filter class="remove-all-metadata-filter"/>
-            <password>test</password>
-            <username>pop3@mail.local</username>
-            <is-attachment>false</is-attachment>
-            <content-type>text/plain</content-type>
-            <content-encoding>quoted-printable</content-encoding>
-            <attachment-content-type>application/octet-stream</attachment-content-type>
-          </producer>
+		  <producer class="send-email">
+			<unique-id>default-smtp-producer</unique-id>
+			<smtp-url>smtp://mail.local:25</smtp-url>
+			<subject>Test email sent by Interlok</subject>
+			<from>pop3@mail.local</from>
+			<session-properties/>
+			<metadata-filter class="remove-all-metadata-filter"/>
+			<password>test</password>
+			<username>pop3@mail.local</username>
+			<to>imap@mail.local</to>
+		  </producer>
           <produce-exception-handler class="null-produce-exception-handler"/>
           <unique-id>file-to-smtp-workflow-no-attachment</unique-id>
           <message-metrics-interceptor>
@@ -251,9 +232,7 @@
         <standard-workflow>
           <consumer class="fs-consumer">
             <unique-id>fs-consumer</unique-id>
-            <destination class="configured-consume-destination">
-              <destination>file:////C:/apps/Adaptris/Interlok/test/mail-pickup-default-with-attachment</destination>
-            </destination>
+			<base-directory-url>file:////C:/apps/Adaptris/Interlok/test/mail-pickup-default-with-attachment</base-directory-url>
             <poller class="fixed-interval-poller">
               <poll-interval>
                 <unit>SECONDS</unit>
@@ -289,23 +268,19 @@
               </copy-metadata-service>
             </services>
           </service-collection>
-          <producer class="default-smtp-producer">
-            <unique-id>default-smtp-producer</unique-id>
-            <destination class="configured-produce-destination">
-              <destination>imap@mail.local</destination>
-            </destination>
-            <smtp-url>smtp://mail.local:25</smtp-url>
-            <subject>Test email with attachment sent by Interlok</subject>
-            <from>pop3@mail.local</from>
-            <session-properties/>
-            <metadata-filter class="remove-all-metadata-filter"/>
-            <password>test</password>
-            <username>pop3@mail.local</username>
-            <is-attachment>true</is-attachment>
-            <content-type>text/plain</content-type>
-            <content-encoding>quoted-printable</content-encoding>
-            <attachment-content-type>application/octet-stream</attachment-content-type>
-          </producer>
+		  <producer class="send-email-attachment">
+			<unique-id>default-smtp-producer</unique-id>
+			<smtp-url>smtp://mail.local:25</smtp-url>
+			<subject>Test email with attachment sent by Interlok</subject>
+			<from>pop3@mail.local</from>
+			<session-properties/>
+			<metadata-filter class="remove-all-metadata-filter"/>
+			<password>test</password>
+			<username>pop3@mail.local</username>
+			<to>imap@mail.local</to>
+			<content-type>text/plain</content-type>
+			<attachment-content-type>application/octet-stream</attachment-content-type>
+		  </producer>
           <produce-exception-handler class="null-produce-exception-handler"/>
           <unique-id>file-to-smtp-workflow-one-attachment</unique-id>
           <message-metrics-interceptor>
@@ -320,9 +295,7 @@
         <standard-workflow>
           <consumer class="fs-consumer">
             <unique-id>fs-consumer</unique-id>
-            <destination class="configured-consume-destination">
-              <destination>file:////C:/apps/Adaptris/Interlok/test/mail-pickup-multi-attachment-mime</destination>
-            </destination>
+			<base-directory-url>file:////C:/apps/Adaptris/Interlok/test/mail-pickup-multi-attachment-mime</base-directory-url>
             <poller class="fixed-interval-poller">
               <poll-interval>
                 <unit>SECONDS</unit>
@@ -337,25 +310,20 @@
             <unique-id>service-list-8919318</unique-id>
             <services/>
           </service-collection>
-          <producer class="multi-attachment-smtp-producer">
-            <unique-id>multi-attachment-smtp-producer</unique-id>
-            <destination class="configured-produce-destination">
-              <destination>imap@mail.local</destination>
-            </destination>
-            <smtp-url>smtp://mail.local:25</smtp-url>
-            <subject>Test email sent by Interlok with multiple attachments from MIME message</subject>
-            <from>pop3@mail.local</from>
-            <session-properties/>
-            <metadata-filter class="remove-all-metadata-filter"/>
-            <password>test</password>
-            <username>pop3@mail.local</username>
-            <mail-creator class="mail-mime-content-creator">
-              <body-selector class="mime-select-by-position">
-                <position>1</position>
-              </body-selector>
-            </mail-creator>
-            <content-encoding>quoted-printable</content-encoding>
-          </producer>
+		  <producer class="send-email-attachment">
+			<encoder class="com.adaptris.core.MultiPayloadMessageMimeEncoder"/>
+			<unique-id>default-smtp-producer</unique-id>
+			<smtp-url>smtp://mail.local:25</smtp-url>
+			<subject>Test email with attachment sent by Interlok</subject>
+			<from>pop3@mail.local</from>
+			<session-properties/>
+			<metadata-filter class="remove-all-metadata-filter"/>
+			<password>test</password>
+			<username>pop3@mail.local</username>
+			<to>imap@mail.local</to>
+			<content-type>text/plain</content-type>
+			<attachment-content-type>application/octet-stream</attachment-content-type>
+		  </producer>
           <produce-exception-handler class="null-produce-exception-handler"/>
           <unique-id>file-to-smtp-workflow-multiple-attachments-from-mime</unique-id>
           <message-metrics-interceptor>
@@ -370,9 +338,7 @@
         <standard-workflow>
           <consumer class="fs-consumer">
             <unique-id>fs-consumer</unique-id>
-            <destination class="configured-consume-destination">
-              <destination>file:////C:/apps/Adaptris/Interlok/test/mail-pickup-multi-attachment-xml</destination>
-            </destination>
+			<base-directory-url>file:////C:/apps/Adaptris/Interlok/test/mail-pickup-multi-attachment-xml</base-directory-url>
             <poller class="fixed-interval-poller">
               <poll-interval>
                 <unit>SECONDS</unit>
@@ -387,31 +353,20 @@
             <unique-id>service-list-8919318</unique-id>
             <services/>
           </service-collection>
-          <producer class="multi-attachment-smtp-producer">
-            <unique-id>multi-attachment-smtp-producer</unique-id>
-            <destination class="configured-produce-destination">
-              <destination>imap@mail.local</destination>
-            </destination>
-            <smtp-url>smtp://mail.local:25</smtp-url>
-            <subject>Test email sent by Interlok with multiple attachments from XML message</subject>
-            <from>pop3@mail.local</from>
-            <session-properties/>
-            <metadata-filter class="remove-all-metadata-filter"/>
-            <password>test</password>
-            <username>pop3@mail.local</username>
-            <mail-creator class="mail-xml-content-creator">
-              <attachment-handler class="mail-xml-attachment-handler">
-                <xpath>/document/attachment</xpath>
-                <filename-xpath>@filename</filename-xpath>
-                <encoding-xpath>@encoding</encoding-xpath>
-              </attachment-handler>
-              <body-handler class="mail-xml-body-handler">
-                <xpath>/document/content</xpath>
-                <content-type>text/plain</content-type>
-              </body-handler>
-            </mail-creator>
-            <content-encoding>quoted-printable</content-encoding>
-          </producer>
+		  <producer class="send-email-attachment">
+			<encoder class="com.adaptris.core.MultiPayloadMessageMimeEncoder"/>
+			<unique-id>default-smtp-producer</unique-id>
+			<smtp-url>smtp://mail.local:25</smtp-url>
+			<subject>Test email sent by Interlok with multiple attachments from XML message</subject>
+			<from>pop3@mail.local</from>
+			<session-properties/>
+			<metadata-filter class="remove-all-metadata-filter"/>
+			<password>test</password>
+			<username>pop3@mail.local</username>
+			<to>imap@mail.local</to>
+			<content-type>text/plain</content-type>
+			<attachment-content-type>application/octet-stream</attachment-content-type>
+		  </producer>
           <produce-exception-handler class="null-produce-exception-handler"/>
           <unique-id>file-to-smtp-workflow-multiple-attachments-from-xml</unique-id>
           <message-metrics-interceptor>

--- a/docs/pages/advanced/advanced-configuration-pre-processors.md
+++ b/docs/pages/advanced/advanced-configuration-pre-processors.md
@@ -36,7 +36,7 @@ preProcessors=variableSubstitution:schema
 
 This pre-processor allows you to configure place-holders in your Interlok configuration, which will be swapped out with values configured in a separate property file. The idea is that multiple environments that require almost identical configuration can more easily be set-up by simply duplicating the main Interlok configuration files across all environments.
 
-Typically broker URL's, usernames, passwords and destination values would be a fair use for variable substitution.
+Typically broker URL's, usernames, passwords and endpoint/queue values would be a fair use for variable substitution.
 
 ### Additional Configuration ###
 
@@ -226,13 +226,12 @@ And you have an xml document named channel.xml that looks like this;
     <standard-workflow>
       <unique-id>SendMessage</unique-id>
       <consumer class="polling-trigger">
-        <destination class="configured-consume-destination">
-          <configured-thread-name>SendMessage</configured-thread-name>
-        </destination>
-        <template>hello world</template>
         <poller class="quartz-cron-poller">
           <cron-expression>*/7 * * * * ?</cron-expression>
         </poller>
+        <message-provider class="static-polling-trigger-template">
+          <template><![CDATA[hello world]]></template>
+        </message-provider>
       </consumer>
       <service-collection class="service-list"/>
     </standard-workflow>
@@ -255,13 +254,12 @@ During initialization of Interlok, the XInclude pre-processor will pick up the d
         <standard-workflow>
           <unique-id>SendMessage</unique-id>
           <consumer class="polling-trigger">
-            <destination class="configured-consume-destination">
-              <configured-thread-name>SendMessage</configured-thread-name>
-            </destination>
-            <template>hello world</template>
             <poller class="quartz-cron-poller">
               <cron-expression>*/7 * * * * ?</cron-expression>
             </poller>
+            <message-provider class="static-polling-trigger-template">
+              <template><![CDATA[hello world]]></template>
+            </message-provider>
           </consumer>
           <service-collection class="service-list"/>
         </standard-workflow>

--- a/docs/pages/advanced/advanced-memory-requirements.md
+++ b/docs/pages/advanced/advanced-memory-requirements.md
@@ -49,6 +49,8 @@ After running Interlok for 30 minutes we can see the heap usage climbs and then 
 
 #### Configuration ####
 
+?> **NOTE**:  The configuration shown on this page was written for Interlok V3; destination elements have been replaced in Interlok V4. 
+
 The most basic of all configurations would consist of a file system consumer and file system producer, without any services.  The effect of this configuration will simply move files from the consuming directory to the configured producer directory. We could reduce the memory usage even further here by disabling Interloks embedded Jetty service which powers Interloks Web UI.  However, for these examples we assume a factory install of Interlok and to show real comparisons between these examples only the specified configuration will be modified beyond that factory install.
 
 ```xml

--- a/docs/pages/advanced/advanced-multi-payload-messages.md
+++ b/docs/pages/advanced/advanced-multi-payload-messages.md
@@ -34,9 +34,7 @@ to originate from any Data Input Parameter String.
         <unique-id>add-payload-unique-id</unique-id>
         <new-payload-id>payload-2</new-payload-id>
         <new-payload class="file-data-input-parameter">
-            <destination class="configured-destination">
-                <destination><!-- path to file to include as new payload --></destination>
-            </destination>
+            <url><!-- path to file to include as new payload --></url>
         </new-payload>
     </add-payload-service>
 ```

--- a/docs/pages/advanced/advanced-profiler-prometheus.md
+++ b/docs/pages/advanced/advanced-profiler-prometheus.md
@@ -220,9 +220,7 @@ service_avgnanos{workflow="standardWorkflow"}
               <default-payload-id>default-payload</default-payload-id>
             </message-factory>
             <unique-id>httpMessageConsumer</unique-id>
-            <destination class="configured-consume-destination">
-              <destination>/endpoint1</destination>
-            </destination>
+            <path>/endpoint1</path>
             <parameter-handler class="jetty-http-ignore-parameters"/>
             <header-handler class="jetty-http-ignore-headers"/>
           </consumer>
@@ -289,9 +287,7 @@ service_avgnanos{workflow="standardWorkflow"}
               <default-payload-id>default-payload</default-payload-id>
             </message-factory>
             <unique-id>secondHttpMessageConsumer</unique-id>
-            <destination class="configured-consume-destination">
-              <destination>/endpoint2</destination>
-            </destination>
+            <path>/endpoint2</path>
             <parameter-handler class="jetty-http-ignore-parameters"/>
             <header-handler class="jetty-http-ignore-headers"/>
           </consumer>


### PR DESCRIPTION
**This is a draft PR while I work out all the references to dest and the updates**

## Still left to do...

I'm not entirely sure that cookbook/email/adapter.xml is correct (2 producers worry me, the last 2 in the config that work with multi attachments)

The following pages still have config examples using the old destination style:
  - advanced-triggered-channel.md
  - advanced-xa-integration.md
  - cookbook-aggregating-messages.md
  - cookbook-flatfile-transform.md
  - cookbook-http-server.md
  - cookbook-jms.md
  - cookbook-json-transform.md
  - cookbook-pop3.md
  - cookbook-sap-rfc.md
  - cookbook-splitting-messages.md
  - cookbook-terracotta-um.md
  - cookbook-triggered-channel.md
  - adapter-what-is-it.md
  - service-tester-configuration.md
  - ui-swagger.md
  - ui-templates.md
  - adapter-error-handling.md
  - adapter-events.md

The following pages probably need reviewing:
  - developer-consumers.md
  - developer-producers.md
  - advanced-jmx-jms.md

---- 

## Motivation

Interlok v4 removed destinations from consumers and producers, and the docs need updating.

## Modification

* docs/files/cookbook/email/adapter.xml - updated so it loads in a v4 adapter (This needs checking)
* docs/pages/advanced/advanced-configuration-pre-processors.md - updated refs to dest, should be fine.
*  docs/pages/advanced/advanced-memory-requirements.md - I left the config examples with the destinations in place, as the results/graphs on the page were created in v3, so I thought it better to leave the page, so I just stuck a note to say the config was v3 and out of date.
* docs/pages/advanced/advanced-multi-payload-messages.md - updated the example add-payload-service xml (dest to url)
* docs/pages/advanced/advanced-profiler-prometheus.md - updated the example jetty-message-consumer (dest to path)

## Result

The doc pages should be up to date with v4 components and references

## Testing

read all the pages that have changed and they should read okay with v4 lang/references.
