### PR TITLE
Interlok 4052 update wmq documentation

### DIFF
--- a/docs/pages/cookbook/cookbook-jms.md
+++ b/docs/pages/cookbook/cookbook-jms.md
@@ -308,7 +308,16 @@ Interlok does not come supplied with any of the required MQSeries java archive f
 
 ### Vendor Implementations ###
 
-The associated vendor implementation class that should be used is [basic-mq-series-implementation][] or, if you want to control the connection factory properties more explicitly, [advanced-mq-series-implementation][]. As well as setting the JMS vendor implementation with the above to options you can also use the native consumer/producer, detailed separately. You can always use the more generic JNDI implementation to connect to IBM MQSeries.
+The associated vendor implementation class that should be used is [basic-mq-series-implementation][] or, if you want to control the connection factory properties more explicitly, [advanced-mq-series-implementation][]. As well as setting the JMS vendor implementation with the above to options you can also use the native consumer/producer, detailed separately, **although they have been deprecated since 3.11.1 without replacement since IBM recommend you use JMS instead**. You can always use the more generic JNDI implementation to connect to IBM MQSeries.
+
+!> **IMPORTANT** Please note that using the the *mq-series-implementations* with an *active-jms-connection-error-handler* has known issues where it will cause the channel containing the connection to close. Depending on your logging level you might see the following error:
+```
+Caused by: com.ibm.mq.MQException: JMSCMQ0001: IBM MQ call failed with compcode '2' ('MQCC_FAILED') reason '2035' ('MQRC_NOT_AUTHORIZED').
+        at com.ibm.msg.client.wmq.common.internal.Reason.createException(Reason.java:203) ~[com.ibm.mq.allclient.jar:9.3.0.1 - p930-001-220907]
+        ... 10 more
+TRACE [JmsConnectionErrorHandler for wmq] [ActiveJmsConnectionErrorHandler] Stop/Close affected component : [Channel(gloomy-wing)]
+``` 
+This is due to an issue with the way WMQ handles permissions.
 
 The standard configuration table is as follows :
 

--- a/docs/pages/cookbook/cookbook-native-wmq.md
+++ b/docs/pages/cookbook/cookbook-native-wmq.md
@@ -2,7 +2,7 @@
 
 > **Summary:** This document summarises configurations for consuming and producing messages using the native IBM WebsphereMQ API.
 
-!> **IMPORTANT** in 3.8.0; adp-webspheremq was renamed to interlok-webspheremq
+!> **IMPORTANT** in 3.8.0; adp-webspheremq was renamed to interlok-webspheremq and the native componenets deprecated since 3.11.1 without replacement since IBM recommend you use JMS instead. 
 
 This document summarises configurations for consuming and producing messages using the native IBM WebsphereMQ API. If you are attaching to WebsphereMQ via JMS, then the [JMS Guide][] contains specifics for that. It assumed that you have a passing knowledge of Interlok and its configuration. This guide has been built with MQSeries version 7.5 in mind.  However if you happen to be using another version, the only changes should be to the java archive files you will need to copy from your MQSeries installation to your Interlok installation, mentioned later in this guide.
 

--- a/docs/pages/cookbook/cookbook-native-wmq.md
+++ b/docs/pages/cookbook/cookbook-native-wmq.md
@@ -2,7 +2,7 @@
 
 > **Summary:** This document summarises configurations for consuming and producing messages using the native IBM WebsphereMQ API.
 
-!> **IMPORTANT** in 3.8.0; adp-webspheremq was renamed to interlok-webspheremq and the native componenets deprecated since 3.11.1 without replacement since IBM recommend you use JMS instead. 
+!> **IMPORTANT** in 3.8.0; adp-webspheremq was renamed to interlok-webspheremq and the native components have been deprecated since 3.11.1 without replacement since IBM recommend you use JMS instead. 
 
 This document summarises configurations for consuming and producing messages using the native IBM WebsphereMQ API. If you are attaching to WebsphereMQ via JMS, then the [JMS Guide][] contains specifics for that. It assumed that you have a passing knowledge of Interlok and its configuration. This guide has been built with MQSeries version 7.5 in mind.  However if you happen to be using another version, the only changes should be to the java archive files you will need to copy from your MQSeries installation to your Interlok installation, mentioned later in this guide.
 


### PR DESCRIPTION
## Motivation

To reflect the fact some components have been deprecated and also to highlight a known issue with WMQ and the active JMS error handler.

## Modification

Changes to two cookbook MD pages.

## PR Checklist

- [x] been self-reviewed.
- [n/a] Added javadocs for most classes and all non-trivial methods
- [n/a] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [n/a] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [n/a] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [n/a] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [n/a ] Added unit tests or modified existing tests to cover new code paths
- [n/a] Tested new/updated components in the UI and at runtime in an Interlok instance
- [n/a] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [n/a] Checked that javadoc generation doesn't report errors
- [n/a] Checked the display of the component in the UI
- [n/a] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

n/a

## Testing

n/a
